### PR TITLE
Only adding 'head' dim to `plain_attention` function docstring

### DIFF
--- a/models/transformer.py
+++ b/models/transformer.py
@@ -28,8 +28,8 @@ def plain_attention(
 ) -> Tuple[Tensor, Tensor]:
     """
     Args:
-        query: (batch, out_seq_len, dim)
-        key_value: (batch, in_seq_len, 2, dim)
+        query: (batch, out_seq_len, head, dim)
+        key_value: (batch, in_seq_len, 2, head, dim)
         mask: (batch, out_seq_len, in_seq_len)
         attention_dropout: dropout probability
         training: whether in training mode


### PR DESCRIPTION
Was just reading your "_Driving with LLMs: Fusing Object-Level Vector Modality for Explainable Autonomous Driving_" paper :D and skimming through the code base a bit